### PR TITLE
Return the complete response, not just first chunk

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 
 var path = require('path');
 var Writable = require('stream').Writable;
-var Transform = require('stream').Transform;
+var concat = require('concat-stream');
 var azure = require( 'azure-storage');
 var _ = require( 'lodash' );
 var mime = require( 'mime' );
@@ -24,21 +24,15 @@ module.exports = function SkipperAzure( globalOptions ) {
     read: function( fd, cb ) {
       var prefix = fd;
 
-      // Build a noop transform stream that will pump the Azure output through
-      var __transform__ = new Transform();
-      __transform__._transform = function (chunk, encoding, callback) {
-        return cb(null, chunk);
-      };
-
-      blobService.getBlobToStream( globalOptions.container, prefix, __transform__, function( err, result, response ) {
+      var res = blobService.createReadStream( globalOptions.container, prefix, function( err ) {
         if ( err ) {
           cb( err );
         }
-
-        __transform__.emit( 'finish', err, result.blob)
       });
 
-      return __transform__
+      res.pipe(concat(function (data) {
+        return cb(null, data);
+      }));
     },
 
     rm: function( fd, cb ) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "azure-storage": "^0.4.2",
+    "concat-stream": "^1.4.7",
     "lodash": "~2.4.1",
     "mime": "^1.3.4"
   }


### PR DESCRIPTION
This fixes an issue where only first chunks are returned for larger files, effectively corrupting the data.

This works so that we instead ask Azure to create a read stream that we will consume, and the `concat-stream` module takes care of combining all the data chunks into one buffer that can be returned to the client.
