### PR TITLE
Revert "Return the complete response, not just first chunk"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "azure-storage": "^0.4.2",
-    "concat-stream": "^1.4.7",
     "lodash": "~2.4.1",
     "mime": "^1.3.4"
   }


### PR DESCRIPTION
Reverts lukasreichart/skipper-azure#3

Sorry about this - the issue with data corruption was caused by my own incorrect usage of the library. It is not very good practice to buffer the whole file into memory before returning it to client, anyway...
